### PR TITLE
fix typo in readme, fix logic in publisher for raw

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ where TCP_IP should be replaced by the IP of the DVL. You can also display the r
 
 **To run the publisher that listens to the TCP port, displays the raw data in the DVL and sends the data to ROS**
 ```bash
-rosrun waterlinked_a50_ros_driver publisher.py _ip:=TCP_IP _do_log_data:=true
+rosrun waterlinked_a50_ros_driver publisher.py _ip:=TCP_IP _do_log_raw_data:=true
 ```
 
 **To run a subscriber node that listens to the DVL topic. Helpful for debugging or checking if everything is running as it should be. Choose between "subscriber_gui.py" and "subscriber.py". The GUI makes reading data visually much easier. While the non-GUI version makes it easier to read through the code to see how you can implement code yourself.**

--- a/scripts/publisher.py
+++ b/scripts/publisher.py
@@ -58,12 +58,22 @@ def publisher():
 	rate = rospy.Rate(10) # 10hz
 	while not rospy.is_shutdown():
 		raw_data = getData()
+		data = json.loads(raw_data)
+
+		# edit: the logic in the original version can't actually publish the raw data
+		# we slightly change the if else statement so now
+		# do_log_raw_data is true: publish the raw data to /dvl/json_data topic, fill in theDVL using velocity data and publish to dvl/data topic
+		# do_log_raw_data is true: only fill in theDVL using velocity data and publish to dvl/data topic
+
 		if do_log_raw_data:
 			rospy.loginfo(raw_data)
-		data = json.loads(raw_data)
-		if data["type"] != "velocity":
-			continue
-		pub_raw.publish(raw_data)
+			pub_raw.publish(raw_data)
+			if data["type"] != "velocity":
+				continue
+		else:
+			if data["type"] != "velocity":
+				continue
+			pub_raw.publish(raw_data)
 
 		theDVL.header.stamp = rospy.Time.now()
 		theDVL.header.frame_id = "dvl_link"


### PR DESCRIPTION
In the readme we found there is a typo in the arg name. So we change do_log_data to do_log_raw_data.

In the publisher.py we fix the logic when do_log_raw_data:=true. We put details in the comment of the script.